### PR TITLE
Added a class for points.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,11 @@ project(mylib VERSION 1.0.1 DESCRIPTION "sandbox library")
 
 enable_testing()
 
-add_subdirectory( src )
+find_package(Boost 1.36.0)
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+  add_subdirectory( src )
+endif()
 
 add_test(NAME MyTest COMMAND Test)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(libgnssro STATIC
-    libgnssro.cpp
+	libgnssro.cpp
     libgnssro.h
+	Point.hpp
 )
 
 set_target_properties(libgnssro PROPERTIES VERSION ${PROJECT_VERSION})

--- a/src/Point.hpp
+++ b/src/Point.hpp
@@ -1,0 +1,180 @@
+#ifndef POINT_HPP_
+#define POINT_HPP_
+
+
+#include <boost/operators.hpp>
+#include <ostream>
+
+
+template< class T , size_t Dim >
+class Point :
+    boost::additive1< Point< T , Dim > ,
+    boost::additive2< Point< T , Dim  > , T ,
+    boost::multiplicative2< Point< T , Dim > , T> > >
+    {
+    public:
+
+        const static size_t dim = Dim;
+
+        // 
+        // Constructors
+        //
+        Point( void )
+        {
+            for( size_t i=0 ; i<dim ; ++i ) m_val[i] = 0.0;
+        }
+
+        Point( T val )
+        {
+            for( size_t i=0 ; i<dim ; ++i ) m_val[i] = val;
+        }
+
+        Point( T x , T y , T z = 0.0 )
+        {
+            if( dim > 0 ) m_val[0] = x;
+            if( dim > 1 ) m_val[1] = y;
+            if( dim > 2 ) m_val[2] = z;
+        }
+
+        Point( Point< T , Dim >& p )
+        {
+            for( size_t ii=0; ii<dim; ++ii )
+                m_val[ii] = p[ii];
+        }
+
+        //  End Constructors
+
+        //  Destructor
+        ~Point(){};
+        //  End Destructor
+
+        // 
+        //  Operators
+        //
+        T operator[]( size_t i ) const { return m_val[i]; }
+        T& operator[]( size_t i ) { return m_val[i]; }
+
+        Point<T,dim>& operator= ( const Point<T,dim>& p )
+        {
+            for( size_t ii=0; ii<dim; ++ii )
+                m_val[ii] = p[ii];
+            return *this;
+        }
+
+        Point<T,dim>& operator+=( const Point<T,dim>& p )
+        {
+            for( size_t ii=0 ; ii<dim ; ++ii )
+                m_val[ii] += p[ii];
+            return *this;
+        }
+
+        Point<T,dim>& operator-=( const Point<T,dim>& p )
+        {
+            for( size_t ii=0; ii<dim; ++ii )
+                m_val[ii] -= p[ii];
+            return *this;
+        }
+
+        Point<T,dim>& operator+=( const T& val )
+        {
+            for( size_t ii=0; ii<dim; ++ii )
+                m_val[ii] += val;
+            return *this;
+        }
+
+        Point<T,dim>& operator-=( const T& val )
+        {
+            for( size_t ii=0; ii<dim; ++ii )
+                m_val[ii] -= val;
+            return *this;
+        }
+
+        Point<T,dim>& operator*=( const T &val )
+        {
+            for( size_t ii=0; ii<dim; ++ii )
+                m_val[ii] *= val;
+            return *this;
+        }
+
+        Point<T,dim>& operator/=( const T &val )
+        {
+            for( size_t i=0 ; i<dim ; ++i )
+                m_val[i] /= val;
+            return *this;
+        }
+
+        //  End Operators
+
+    private:
+
+        // Actual Point coordinates are private (access via [] operator):
+        T m_val[dim];
+
+    };
+
+    //
+    //  Additional vector operators
+    //
+
+    //
+    //  the - operator
+    //
+    template< class T , size_t Dim >
+    Point< T , Dim > operator-( const Point< T , Dim > &p )
+    {
+        Point< T , Dim > tmp;
+        for( size_t i=0 ; i<Dim ; ++i ) tmp[i] = -p[i];
+        return tmp;
+    }
+
+    //
+    //  Inner product
+    //
+    template< class T , size_t Dim >
+    T scalar_prod( const Point< T , Dim > &p1 , const Point< T , Dim > &p2 )
+    {
+        T tmp = 0.0;
+        for( size_t i=0 ; i<Dim ; ++i ) tmp += p1[i] * p2[i];
+        return tmp;
+    }
+
+
+
+    //
+    //  L^1 norm
+    //
+    template< class T , size_t Dim >
+    T norm( const Point< T , Dim > &p1 )
+    {
+        return scalar_prod( p1 , p1 );
+    }
+
+
+
+
+    //
+    //  L^2 norm
+    //
+    template< class T , size_t Dim >
+    T abs( const Point< T , Dim > &p1 )
+    {
+        return sqrt( norm( p1 ) );
+    }
+
+
+
+
+    //
+    //  output stream operator
+    //
+    template< class T , size_t Dim >
+    std::ostream& operator<<( std::ostream &out , const Point< T , Dim > &p )
+    {
+        if( Dim > 0 ) out << p[0];
+        for( size_t i=1 ; i<Dim ; ++i ) out << " " << p[i];
+        return out;
+    }
+
+
+
+#endif  //  POINT_HPP_

--- a/src/libgnssro.h
+++ b/src/libgnssro.h
@@ -1,6 +1,8 @@
 #ifndef _LIBGNSSRO_H
 #define _LIBGNSSRO_H
 
+#include "Point.hpp"
+
 class Planck
 {
 	const float h;


### PR DESCRIPTION
<h1> Description </h1>
This PR adds a simple class to describe points in space, either 1, 2, or 3D cartesian space.
Higher dimensions are not required right now.

A point can be created as e.g.:
```C++
//   Creates a 3D point with double coordimates:
Point<double,3> x;  //  The default constructor locates the point at the origin. 
```

This is a prerequisite for the `Medium` classes that describe the spatial extent of a refracting medium, amongst other things.

<h2> Issues: </h2>
The following issues are addressed:
- Fixes #4 

<h2> Dependencies: </h2>
None.